### PR TITLE
Fix APT repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 from	f69m/ubuntu32:14.04
 
 # make sure the package repository is up to date
-run	echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+run	echo "deb http://old-releases.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
 run	apt-get update
 
 # Install vnc, xvfb in order to create a 'fake' display and firefox


### PR DESCRIPTION
* Dockerfile: Update APT repository for `old-releases` since the former doesn’t exist anymore.